### PR TITLE
Throw if resolver isn't set

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,7 @@ const networkMap = require('ethereum-ens-network-map')
 const emptyHash = '0x0000000000000000000000000000000000000000000000000000000000000000'
 const emptyAddr = '0x0000000000000000000000000000000000000000'
 
-const NotFoundError = new Error('ENS name not found.')
-const ResolverNotFound = new Error('ENS resolver not found.')
+const NotFoundError = new Error('ENS name not defined.')
 
 class Ens {
 
@@ -102,7 +101,7 @@ class Ens {
     .then((result) => {
       const resolverAddress = result[0]
       if (resolverAddress === emptyAddr) {
-        throw ResolverNotFound
+        throw NotFoundError
       }
       return resolverAddress
     })
@@ -114,12 +113,6 @@ class Ens {
       return resolver.addr(node)
     })
     .then(result => result[0])
-    .catch((reason) => {
-      if (reason === ResolverNotFound) {
-        return this.getOwnerForNode(node)
-      }
-      throw reason
-    })
   }
 
   reverse (address) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethjs-ens",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "An ENS interface module built on EthJS.",
   "main": "index.js",
   "scripts": {

--- a/test/mainnet.js
+++ b/test/mainnet.js
@@ -1,0 +1,110 @@
+const test = require('tape')
+const HttpProvider = require('ethjs-provider-http')
+const provider = new HttpProvider('https://mainnet.infura.io')
+
+const ENS = require('../')
+const ens = new ENS({ provider, network: '1' })
+test('not providing a network throws', function (t) {
+  t.plan(1)
+  t.throws(function() {
+    const sample = new ENS({ provider })
+  })
+})
+
+test('not providing a provider throws', function (t) {
+  t.plan(1)
+  t.throws(function() {
+    const sample = new ENS({ network: '1' })
+  })
+})
+
+test('lookup apt-get.eth', function (t) {
+  t.plan(1)
+
+  ens.lookup('apt-get.eth')
+  .then((address) => {
+    const expected = '0xd1ccfbf0a0dc2a9ed8a496b07e81dd8ecd7cb00e'
+    t.equal(address, expected)
+    t.end()
+  })
+  .catch((reason) => {
+    t.ok(false)
+  })
+})
+
+test('getOwner for nobodywantsthisdomain.eth', function (t) {
+  t.plan(1)
+
+  ens.getOwner('nobodywantsthisdomain.eth')
+  .then((owner) => {
+    console.log('it is owned ', owner)
+    t.ok(owner)
+    t.end()
+  })
+  .catch((reason) => {
+    t.equal(reason.message, 'ENS name not found.')
+  })
+})
+
+test('getOwner empty name', function (t) {
+  t.plan(1)
+
+  ens.getOwner('')
+  .catch((reason) => {
+    t.equal(reason.message, 'ENS name not found.')
+  })
+})
+
+test('getResolver empty name', function (t) {
+  t.plan(1)
+
+  ens.getOwner('')
+  .catch((reason) => {
+    t.equal(reason.message, 'ENS name not found.')
+  })
+})
+
+test('reverse vitalik.eth address should return address', function (t) {
+  t.plan(1)
+
+  const address = '0xd1ccfbf0a0dc2a9ed8a496b07e81dd8ecd7cb00e'
+  ens.reverse(address)
+  .then((name) => {
+    const expected = 'vitalik.eth'
+    t.equal(name, expected)
+  })
+  .catch((reason) => {
+    t.ok(false, reason)
+  })
+})
+
+test('lookup nobodywantsthisdomain.eth address', function (t) {
+  t.plan(1)
+
+  ens.lookup('nobodywantsthisdomain.eth')
+  .catch((reason) => {
+    t.equal(reason.message, 'ENS name not found.')
+  })
+})
+
+test('lookup bar.eth address', function (t) {
+  t.plan(1)
+
+  ens.lookup('bar.eth')
+  .then((address) => {
+    t.equal(address, '0xd0b85aad460f5835c2349fbdd065b2389c921ce1')
+  })
+  .catch((reason) => {
+    t.equal(reason.message, 'ENS name not found.')
+  })
+})
+
+test('lookup empty address', function (t) {
+  t.plan(1)
+
+  ens.lookup('')
+  .catch((reason) => {
+    t.equal(reason.message, 'ENS name not found.')
+  })
+})
+

--- a/test/ropsten.js
+++ b/test/ropsten.js
@@ -1,6 +1,7 @@
 const test = require('tape')
 const HttpProvider = require('ethjs-provider-http')
 const provider = new HttpProvider('https://ropsten.infura.io')
+const notFound = 'ENS name not defined.'
 
 const ENS = require('../')
 const ens = new ENS({ provider, network: '3' })
@@ -33,7 +34,7 @@ test('getOwner for nobodywantsthisdomain.eth', function (t) {
 
   ens.getOwner('nobodywantsthisdomain.eth')
   .catch((reason) => {
-    t.equal(reason.message, 'ENS name not found.')
+    t.equal(reason.message, notFound)
   })
 })
 
@@ -42,7 +43,7 @@ test('getOwner empty name', function (t) {
 
   ens.getOwner('')
   .catch((reason) => {
-    t.equal(reason.message, 'ENS name not found.')
+    t.equal(reason.message, notFound)
   })
 })
 
@@ -51,7 +52,7 @@ test('getResolver empty name', function (t) {
 
   ens.getOwner('')
   .catch((reason) => {
-    t.equal(reason.message, 'ENS name not found.')
+    t.equal(reason.message, notFound)
   })
 })
 
@@ -127,7 +128,7 @@ test('lookup nobodywantsthisdomain.eth address', function (t) {
 
   ens.lookup('nobodywantsthisdomain.eth')
   .catch((reason) => {
-    t.equal(reason.message, 'ENS name not found.')
+    t.equal(reason.message, notFound)
   })
 })
 
@@ -141,7 +142,7 @@ test('lookup bar.eth address', function (t) {
   })
   .catch((reason) => {
     console.log('VACATION RENTALS FAIL')
-    t.equal(reason.message, 'ENS name not found.')
+    t.equal(reason.message, notFound)
   })
 })
 
@@ -150,7 +151,7 @@ test('lookup empty address', function (t) {
 
   ens.lookup('')
   .catch((reason) => {
-    t.equal(reason.message, 'ENS name not found.')
+    t.equal(reason.message, notFound)
   })
 })
 

--- a/test/testrpc.js
+++ b/test/testrpc.js
@@ -11,6 +11,7 @@ const ENS = require('../')
 const namehash = require('eth-ens-namehash')
 
 const emptyAddress = '0x0000000000000000000000000000000000000000'
+const notFound = 'ENS name not defined.'
 
 const provider = TestRPC.provider()
 const eth = new Eth(provider)
@@ -66,7 +67,7 @@ test('setup', { timeout: 5000 }, function (t) {
 test('#getResolver() with invalid name should throw', function (t) {
   ens.getResolver('havasupai.eth')
   .catch((result) => {
-    t.equal(result.message, 'ENS resolver not found.')
+    t.equal(result.message, notFound)
     t.end()
   })
 })
@@ -104,10 +105,18 @@ test('#lookup() should get resolver addresses', function (t) {
   })
 })
 
-test('#lookup() with bad name should throw', function (t) {
+test('#lookup() name with no resolver should throw', function (t) {
   ens.lookup('cardassian.eth')
   .catch((reason) => {
-    t.equal(reason.message, 'ENS name not found.')
+    t.equal(reason.message, 'ENS name not defined.')
+    t.end()
+  })
+})
+
+test('#lookup() with unregistered should throw', function (t) {
+  ens.lookup('blargadegh.eth')
+  .catch((reason) => {
+    t.equal(reason.message, notFound)
     t.end()
   })
 })


### PR DESCRIPTION
Fixes #6

Also changes the wording of our error message to suggest the name is not defined, which can represent either not registered or not assigned, and so this is a breaking change.

Accidentally checked in some main-net tests that I'd written that don't fully pass, but are nice to have around, so I don't mind checking them in.