### PR TITLE
Add eslint as devDeps and fix lint errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ const NotFoundError = new Error('ENS name not defined.')
 const BadCharacterError = new Error('Illegal Character for ENS.')
 
 class Ens {
-
   constructor (opts = {}) {
     const { provider, network } = opts
     let { registryAddress } = opts
@@ -49,12 +48,12 @@ class Ens {
 
   lookup (name = '') {
     return this.getNamehash(name)
-    .then((node) => {
-      if (node === emptyHash) {
-        return Promise.reject(NotFoundError)
-      }
-      return this.resolveAddressForNode(node)
-    })
+      .then((node) => {
+        if (node === emptyHash) {
+          return Promise.reject(NotFoundError)
+        }
+        return this.resolveAddressForNode(node)
+      })
   }
 
   getNamehash (name) {
@@ -67,7 +66,7 @@ class Ens {
 
   getOwner (name = '') {
     return this.getNamehash(name)
-    .then(node => this.getOwnerForNode(node))
+      .then(node => this.getOwnerForNode(node))
   }
 
   getOwnerForNode (node) {
@@ -75,24 +74,24 @@ class Ens {
       return Promise.reject(NotFoundError)
     }
     return this.registry.owner(node)
-    .then((result) => {
-      const ownerAddress = result[0]
-      if (ownerAddress === emptyAddr) {
-        throw NotFoundError
-      }
+      .then((result) => {
+        const ownerAddress = result[0]
+        if (ownerAddress === emptyAddr) {
+          throw NotFoundError
+        }
 
-      return ownerAddress
-    })
+        return ownerAddress
+      })
   }
 
   getResolver (name = '') {
     return this.getNamehash(name)
-    .then(node => this.getResolverForNode(node))
+      .then(node => this.getResolverForNode(node))
   }
 
   getResolverAddress (name = '') {
     return this.getNamehash(name)
-    .then(node => this.getResolverAddressForNode(node))
+      .then(node => this.getResolverAddressForNode(node))
   }
 
   getResolverForNode (node) {
@@ -101,28 +100,28 @@ class Ens {
     }
 
     return this.getResolverAddressForNode(node)
-    .then((resolverAddress) => {
-      return this.Resolver.at(resolverAddress)
-    })
+      .then((resolverAddress) => {
+        return this.Resolver.at(resolverAddress)
+      })
   }
 
   getResolverAddressForNode (node) {
     return this.registry.resolver(node)
-    .then((result) => {
-      const resolverAddress = result[0]
-      if (resolverAddress === emptyAddr) {
-        throw NotFoundError
-      }
-      return resolverAddress
-    })
+      .then((result) => {
+        const resolverAddress = result[0]
+        if (resolverAddress === emptyAddr) {
+          throw NotFoundError
+        }
+        return resolverAddress
+      })
   }
 
   resolveAddressForNode (node) {
     return this.getResolverForNode(node)
-    .then((resolver) => {
-      return resolver.addr(node)
-    })
-    .then(result => result[0])
+      .then((resolver) => {
+        return resolver.addr(node)
+      })
+      .then(result => result[0])
   }
 
   reverse (address) {
@@ -137,11 +136,10 @@ class Ens {
     const name = `${address.toLowerCase()}.addr.reverse`
     const node = namehash(name)
     return this.getNamehash(name)
-    .then(node => this.getResolverForNode(node))
-    .then(resolver => resolver.name(node))
-    .then(results => results[0])
+      .then(node => this.getResolverForNode(node))
+      .then(resolver => resolver.name(node))
+      .then(results => results[0])
   }
-
 }
 
 module.exports = Ens

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.12.0",
+    "eslint": "^4.7.1",
     "ethereumjs-testrpc": "^3.0.3",
     "ethjs": "^0.2.5",
     "ethjs-provider-http": "^0.1.6",


### PR DESCRIPTION
Since `eslint` is used in the scripts at [package.json#7](https://github.com/ethjs/ethjs-ens/blob/f9482d5f553c9b41be916bdd91f839d1b8cb5bb8/package.json#L7), it also should be added as deps. Then users don't need to install it as a global deps because `npm run` add `node_modules/.bin` to `PATH` automatically.

After that, the following logs are displayed when I ran `npm test`:
<details><summary>click here</summary>

```console
$ npm test

> ethjs-ens@2.0.1 test /Users/watilde/Development/ethjs-ens
> npm run lint && istanbul cover test && npm run coveralls

> ethjs-ens@2.0.1 lint /Users/watilde/Development/ethjs-ens

/Users/watilde/Development/ethjs-ens/index.js
   18:11  warning  Block must not be padded by blank lines        padded-blocks
   52:1   error    Expected indentation of 6 spaces but found 4   indent
   53:1   error    Expected indentation of 8 spaces but found 6   indent
   54:1   error    Expected indentation of 10 spaces but found 8  indent
   55:1   error    Expected indentation of 8 spaces but found 6   indent
   56:1   error    Expected indentation of 8 spaces but found 6   indent
   57:1   error    Expected indentation of 6 spaces but found 4   indent
   70:1   error    Expected indentation of 6 spaces but found 4   indent
   78:1   error    Expected indentation of 6 spaces but found 4   indent
   79:1   error    Expected indentation of 8 spaces but found 6   indent
   80:1   error    Expected indentation of 8 spaces but found 6   indent
   81:1   error    Expected indentation of 10 spaces but found 8  indent
   82:1   error    Expected indentation of 8 spaces but found 6   indent
   84:1   error    Expected indentation of 8 spaces but found 6   indent
   85:1   error    Expected indentation of 6 spaces but found 4   indent
   90:1   error    Expected indentation of 6 spaces but found 4   indent
   95:1   error    Expected indentation of 6 spaces but found 4   indent
  104:1   error    Expected indentation of 6 spaces but found 4   indent
  105:1   error    Expected indentation of 8 spaces but found 6   indent
  106:1   error    Expected indentation of 6 spaces but found 4   indent
  111:1   error    Expected indentation of 6 spaces but found 4   indent
  112:1   error    Expected indentation of 8 spaces but found 6   indent
  113:1   error    Expected indentation of 8 spaces but found 6   indent
  114:1   error    Expected indentation of 10 spaces but found 8  indent
  115:1   error    Expected indentation of 8 spaces but found 6   indent
  116:1   error    Expected indentation of 8 spaces but found 6   indent
  117:1   error    Expected indentation of 6 spaces but found 4   indent
  122:1   error    Expected indentation of 6 spaces but found 4   indent
  123:1   error    Expected indentation of 8 spaces but found 6   indent
  124:1   error    Expected indentation of 6 spaces but found 4   indent
  125:1   error    Expected indentation of 6 spaces but found 4   indent
  140:1   error    Expected indentation of 6 spaces but found 4   indent
  141:1   error    Expected indentation of 6 spaces but found 4   indent
  142:1   error    Expected indentation of 6 spaces but found 4   indent
  145:1   warning  Block must not be padded by blank lines        padded-blocks

✖ 35 problems (33 errors, 2 warnings)
```
</details>

<br>
This patch is to fix them. Thanks!
